### PR TITLE
Improving the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-all:
+
+all: commands
+
+commands: examples/commands.go
 	go build examples/commands.go
-	mv ./commands ./spotify
-	sudo mv ./spotify /usr/bin/
+
+install: all
+	mv commands /usr/bin/spotify
+
+.PHONY = clean
+clean:
+	rm commands


### PR DESCRIPTION
- Split into make and make install per convention
- Added clean rule

New steps to build:
make
sudo make install

This way you'll only build the commands binary when the commands.go file has changed

im helpful
